### PR TITLE
Radiant slab model update

### DIFF
--- a/src/cetc/radiant_floor.F
+++ b/src/cetc/radiant_floor.F
@@ -245,7 +245,7 @@ C     Flag indicating if radiant floor is active, number of radiant floors, indi
       LOGICAL RadFloor_active
       INTEGER NRadFloor
       INTEGER IRadFloor(MPCOM), InitRadFloor(MPCOM)
-      INTEGER irf
+      INTEGER irf, InsulationLayer
 C----------------------------------------------------------------------
 C     Trace output
       IF(ITC.GT.0.AND.NSINC.GE.ITC.AND.NSINC.LE.ITCF.AND.
@@ -302,6 +302,9 @@ C     Zone surface No.
 C     Surface injection node No.
       In = INT( ADATA(IPCOMP,9) )
 
+C     Layer of insulation
+      InsulationLayer = ADATA(IPCOMP,10)
+
 C     Area of the radiant surface
       AreaR   = SNA(Iz, Is)
 
@@ -337,9 +340,10 @@ C     Layer specific heat
          SHT  = THRMLI(Iz,Is,J,3)
 C     Layer thickness
          THKL = THRMLI(Iz,Is,J,4)
-
+      IF(J .GT. InsulationLayer) THEN
          THKC = THKC + THKL
-
+      ENDIF
+      
 C     Find the resistance of the air gap associated with layer J.
          IF(NairGap .GT. 0 .AND. THRMLI(Iz,Is,J,1) .LT. Small)THEN
             DO 12 iNairGap =1, NairGap
@@ -356,8 +360,12 @@ C     Find the resistance of the air gap associated with layer J.
             IF(In .EQ. Ncentr  ) Xqc = THKC - THKL/2.
             IF(In .EQ. Ncentr-1) Xqc = THKC - THKL
          ENDIF
+      IF(J .GT. InsulationLayer) THEN
          AKslab  = AKslab  + COND*THKL
          RCPslab = RCPslab + DENS*SHT*THKL
+      ENDIF
+      
+         
  11   CONTINUE
 
 C     average thermal conductivity, diffusivity and volumetric


### PR DESCRIPTION
The current model is not accurate when a material with thermal properties very different than the slab is included in the construction.
Typically, this layer would be an insulation layer (conductivity much lower than that of slab material).
This commit allows for the user to specify the insulation layer in the construction.  All layers "below" that layer are ignored when calculating the 2D conduction.
An extra parameter is required in the plant database.  This will be added soon in the Databases directory.
The extra parameter can be set to zero if the user does not want to specify an insulation layer.  If the parameter is set to zero, the solution will be the same as before the changes to the code.
