### PR TITLE
Fix typos in Readme about git.

### DIFF
--- a/Readme
+++ b/Readme
@@ -78,7 +78,7 @@ at <https://github.com/ESP-rCommunity. Although you can compile ESP-r
 with only the ESP-rSource.git to get full functionality you have
 to checkout all four repositories and create a new folder structure 
 to hold the combined distribution. Assuming the folder for downloads is
-ESPrgit and the combined distribution will be in ESPr_Master give
+"ESPrgit" and the combined distribution will be in "ESP-rMaster" give
 the following commands:
 
  mkdir ESPrgit
@@ -88,13 +88,13 @@ the following commands:
  git clone --recursive https://github.com/ESP-rCommunity/ESP-rModels.git
  git clone --recursive https://github.com/ESP-rCommunity/ESP-rDoc.git
 
-Now use a utility called rsync to merge the repositories into ESPr_Master:
+Now use a utility called rsync to merge the repositories into "ESP-rMaster":
 
  mkdir ESP-rMaster
  rsync -av ESP-rSource/ ESP-rMaster/
- rsync -av ESP-rDatabases/ ESPrMaster/data/
- rsync -av ESP-rDoc/ ESPrMaster/doc/
- rsync -av ESP-rModels/ ESPrMaster/models/
+ rsync -av ESP-rDatabases/ ESP-rMaster/data/
+ rsync -av ESP-rDoc/ ESP-rMaster/doc/
+ rsync -av ESP-rModels/ ESP-rMaster/models/
 
 You can learn more about accessing the ESP-r repository here:
 


### PR DESCRIPTION
Fix minor typos in instructions regarding the folder in which to merge distributions.