### PR TITLE
This commit add a change to the DHW module. When calculating the heat…

### DIFF
--- a/src/cetc/DHW_module.F
+++ b/src/cetc/DHW_module.F
@@ -1408,6 +1408,7 @@ c REAL SUBROUTINE sDHW_Update
 c Update variables that relate to ESP-r data.
 c Created by: Phylroy A. Lopez
 c Initial Creation Date:  March 23th 2001
+c Edited by: AW, Nov 6, 2017
 c Copyright 2000: NRCan Buildings Group
 
 c----56--1---------2---------3---------4---------5---------6---------7---------8
@@ -1421,8 +1422,13 @@ c----56--1---------2---------3---------4---------5---------6---------7---------8
 #include "dhw_common.h"
 #include "ground_temp_mains_common.h"
 
+C TFA(MCOM),           ! zone future temperatures
+      common/FVALA/TFA(MCOM),QFA(MCOM)
+      real tfa, qfa
+
 C Note this should be changed to the zone temperature that  the tank is in.
-      fRoomTemp = 20.0
+C      fRoomTemp = 20.0
+       fRoomTemp = tfa(iDHWZoneLocation)
 
       RETURN
 


### PR DESCRIPTION
… loss from the tank to the zone, a constant boundary temperature was assumed. The computed gain was then passed to the thermal zone. In this code update, the future temperature of the zone is used the boundary condition. The updated code compiles on Cygwin, however tester has not been run.